### PR TITLE
fix compiler warning; fix non-atomic reading of RTC counter

### DIFF
--- a/src/stm32f1_rtc.h
+++ b/src/stm32f1_rtc.h
@@ -190,7 +190,7 @@ public:
   }
   
   inline bool isInitialized() {
-    return BKP_DR[RTC_INIT_REG] & RTC_INIT_FLAG == RTC_INIT_FLAG;
+    return (BKP_DR[RTC_INIT_REG] & RTC_INIT_FLAG) == RTC_INIT_FLAG;
   }
   
   inline bool isCounterUpdated() {

--- a/src/stm32f1_rtc.h
+++ b/src/stm32f1_rtc.h
@@ -166,6 +166,7 @@ public:
   void attachInterrupt(InterruptMode im, void (*handler)(void));
   void detachInterrupt(InterruptMode im);
   void setTime(uint32_t time);
+  uint32_t getTime();
   void setAlarmTime(uint32_t time);
   uint16_t getMilliseconds();
   uint16_t getBackupRegister(uint8_t idx);
@@ -215,10 +216,6 @@ public:
   
   inline void clearOverflowFlag() {
     RTC_CRL &= ~RTC_CRL_OWF;
-  }
-  
-  inline uint32_t getTime() {
-    return (RTC_CNTH << 16) | RTC_CNTL;
   }
   
   inline void enableClockInterface() {


### PR DESCRIPTION
Hi,
Thanks for writing this library and making it available under the MIT License.

Your library was mentioned in https://github.com/stm32duino/STM32RTC/issues/29 as an alternative to the STM32RTC library, to solve the problem on the STM32F1 which drops the date fields upon power reset. I have verified that your library works, and I was able to extract the minimum that I needed for my own library (you are given credit in my library). However during the refactoring process, I noticed 2 problems with your library. I am sending you this PR with 2 commits addressing the 2 problems.

It's totally up to you what you do with this, but I think it would be useful for any future users of your library. My own library already has these fixes, so I am not dependent on you accepting this PR.

Regards,
Brian

* a4bebda Fix incorrect bit-wise-and operator precedence
* 3b1234c Handle non-atomic reading of RTC_CNTH and RTC_CNTL
